### PR TITLE
Oppdatere hvilke etasjer bokskap finnes på OJD-hus.

### DIFF
--- a/pages/fagutvalget.md
+++ b/pages/fagutvalget.md
@@ -67,8 +67,7 @@ i styrer og utvalg.
 
 ### Bokskap
 
-FUI tilbyr bokskap som studenter kan ta i bruk. Disse finner du i 3. etasje i
-Ole-Johan Dahls hus.
+FUI tilbyr bokskap som studenter kan ta i bruk. Skapene kan du finne fra 3. etasje til 9. etasje i Ole-Johan Dahls hus.
 
 ### Kursevaluering
 


### PR DESCRIPTION
- Oppdatert beskrivelsen på hvilke etasjer det finnes bokskap i til å inkludere etasjer fra 4. etasje og oppover til 9. etasje. 
- Tar ikke med 10. etasje for øyeblikket da jeg er ganske sikker på at det ikke finnes bokskap der.
- Resolves #73 