### PR TITLE
GF V26: hanneahu forslag 2 -- spesifisere roller men ikke ny paragraf

### DIFF
--- a/pages/vedtekter.md
+++ b/pages/vedtekter.md
@@ -26,8 +26,8 @@ En IFI-student defineres som en programstudent ved IFI v/UiO, eller en student s
 #### **§2 Styret**
 
 1. Styret består av 8-13 personer.
-2. Styret skal bestå av Leder, Nestleder og Økonomiansvarlig. Samme person kan ikke inneha mer enn ett av disse vervene. Andre roller kan opprettes av styret ved behov.
-3. Hvis komposisjonen av styret ikke følger §2.1 og §2.2 skal det prøves løst ved etterfylling innen neste styremøte. Hvis det ikke løses må det kalles inn til ekstraordinær generalforsamling.
+2. Styret skal bestå av Leder, Nestleder og Økonomiansvarlig, PR-ansvarlig, Arrangementsansvarlig, Kursansvarlig, Web-ansvarlig og Skapansvarlig. Samme person kan ikke inneha mer enn ett av disse vervene.
+3. Andre roller kan opprettes av styret ved behov. Hvis komposisjonen av styret ikke følger §2.1 og §2.2 skal det prøves løst ved etterfylling innen neste styremøte. Hvis det ikke løses må det kalles inn til ekstraordinær generalforsamling.
 4. Leder alene, og to styremedlemmer i fellesskap har signaturrett.
 5. Styret er vedtaksdyktig når minst halvparten av medlemmene er til stede.
 6. Styrevedtak fattes ved simpelt flertall.


### PR DESCRIPTION
Oppsummering: Tydeliggjør hvilke roller som finnes i styret utover leder+nestleder+øko. Mye overlapp mot #127 , men lar være å lage en ny paragraf. 

---

Innmelder: hanneahu

Oppgitt begrunnelse:

> Fordeling av roller på første styremøte er dagens praksis i FUI. Det har vært noe utfordringer med at folk skal påta seg en slik rolle, og ved å legge det inn i vedtektene er dette både en formalisering av dagens praksis. I tillegg kan man vurdere på sikt om flere av disse vervene burde velges på generalforsamling. Jeg har også sendt inn forslag på det så kan generalforsamlingen ta stilling til dette, det er forslaget over. 